### PR TITLE
chore(DEVOPS-8186): fix extends to new public repository

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>Lendable/renovate-config"
+    "local>Lendable/renovate-config-public"
   ]
 }


### PR DESCRIPTION
[DEVOPS-8186]

This is a newly created renovate-config repository which is intended to contain the bulk of the renovate config and be private.  It has been mirrored from renovate-config.

As such we just need to tweak the base config to extend from this new repo.

[DEVOPS-8186]: https://lendable-uk.atlassian.net/browse/DEVOPS-8186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ