### PR TITLE
fix: correct settings for golang deps

### DIFF
--- a/default.json
+++ b/default.json
@@ -143,9 +143,9 @@
         },
         {
             "matchManagers": ["gomod"],
-            "matchDepTypes": ["golang"],
             "groupName": "Go dependencies",
             "groupSlug": "go",
+            "postUpdateOptions": ["gomodTidy"],
             "enabled": true
         },
         {


### PR DESCRIPTION
In it's current form, this does not work. These settings have been verified using overrides in one golang project and we are now moving it to shared in this PR.