### PR TITLE
chore(DEVOPS-9802): Add rangeStrategy bump for tflint-plugin manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -260,7 +260,8 @@
             "matchManagers": ["tflint-plugin"],
             "enabled": true,
             "groupName": "TFLint plugins",
-            "groupSlug": "tflint-plugins"
+            "groupSlug": "tflint-plugins",
+            "rangeStrategy": "bump"
         }
     ]
 }


### PR DESCRIPTION
## Summary

Adds `rangeStrategy: "bump"` to the tflint-plugin packageRule to fix Renovate not creating PRs for tflint plugin updates.

## Problem

Renovate was detecting tflint plugins in `.tflint.hcl` files but not creating update PRs. Investigation of the Renovate logs showed:

- The `github-releases` datasource lookups were being **skipped**
- No `renovate/tflint-plugins` branch was being created
- The dependency dashboard showed plugins as "Detected" but with no available updates

## Root Cause

The global config has `rangeStrategy: "in-range-only"`, but tflint plugins use **exact versions** (e.g., `version = "0.41.0"`), not version ranges.

With `in-range-only`, Renovate only updates if the new version satisfies the existing range - but exact versions aren't ranges, so updates were effectively disabled.

## Solution

Add `rangeStrategy: "bump"` to the tflint-plugin rule, which tells Renovate to bump the version to the latest available, even for exact/pinned versions.

## Testing

After merging, trigger a Renovate run on [Lendable/env.iac-modules](https://github.com/Lendable/env.iac-modules) via the Dependency Dashboard to verify tflint plugin updates are now detected and PRs are created.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author