### PR TITLE
Block Gradle Actions v6 major upgrades pending license review

### DIFF
--- a/default.json
+++ b/default.json
@@ -194,6 +194,12 @@
             "pinDigests": false
         },
         {
+            "matchManagers": ["github-actions"],
+            "matchPackageNames": ["gradle/actions"],
+            "matchUpdateTypes": ["major"],
+            "enabled": false
+        },
+        {
             "matchManagers": ["poetry"],
             "enabled": true,
             "groupName": "Poetry dependencies",


### PR DESCRIPTION
## Summary

This PR adds a Renovate package rule to prevent automatic upgrades from Gradle Actions v5 to v6 across all repositories.

## Background

Gradle just released v6 of their GitHub Actions (`gradle/actions`), which introduces a significant **licensing change**:

- **v5 (current):** Fully open source (MIT license)
- **v6 (new):** Caching functionality moved to proprietary `gradle-actions-caching` component governed by [Gradle Terms of Use](https://gradle.com/legal/terms-of-use/)

All 12 of our SuperApp microservices currently use Gradle Actions v5 with caching enabled <- THIS IS DEFAULT.

## What Changed in v6

### Licensing
- Core action remains MIT-licensed
- **Caching component is now proprietary** (requires accepting Gradle ToU)
- Gradle guarantees free for public repos
- Private repos are free now, but Gradle reserves right to introduce restrictions

### Functional Changes
- ✅ Caching works identically to v5
- ❌ Experimental configuration-cache support removed (being reworked)

More details: https://blog.gradle.org/github-actions-for-gradle-v6

## This Change

Adds the following rule to `default.json`:

```json
{
  "matchManagers": ["github-actions"],
  "matchPackageNames": ["gradle/actions"],
  "matchUpdateTypes": ["major"],
  "enabled": false
}
```

**Effect:**
- ✅ Blocks v5 → v6 upgrades
- ✅ Still allows v5.x.x patch/minor updates
- ✅ Applies to all repos using central config

## Next Steps

1. Legal/Commercial review of Gradle Terms of Use
2. Engineering decision on whether to accept licensing change
3. Remove this rule once decision is made to proceed with v6

## Testing

- [x] JSON validation passes
- [x] Rule syntax is valid per [Renovate docs](https://docs.renovatebot.com/configuration-options/#packagerules)

## Related

- Gradle v6 Blog Post: https://blog.gradle.org/github-actions-for-gradle-v6
- Gradle Terms of Use: https://gradle.com/legal/terms-of-use/
