### PR TITLE
fix(gomod): set rangeStrategy to bump

### DIFF
--- a/default.json
+++ b/default.json
@@ -169,6 +169,7 @@
             "groupName": "Go dependencies",
             "groupSlug": "go",
             "postUpdateOptions": ["gomodTidy"],
+            "rangeStrategy": "bump",
             "enabled": true
         },
         {


### PR DESCRIPTION
## Summary

Top-level `rangeStrategy: "in-range-only"` suppresses minor/major updates for `gomod` — each `require` line is a pinned version with no range, so new releases are treated as out-of-range. Only vulnerability-flagged updates and digest-based pseudo-versions get through.

Override on the `gomod` rule to `"bump"`, matching the explicit rangeStrategy set on the `docker`, `github-actions`, and `composer` rules in this file.